### PR TITLE
Fixes transitionStyles related bug on some versions of chrome

### DIFF
--- a/owl-carousel/owl.carousel.js
+++ b/owl-carousel/owl.carousel.js
@@ -803,7 +803,7 @@ if (typeof Object.create !== "function") {
                                   "; transform:"         + translate3D;
             regex = /translate3d\(0px, 0px, 0px\)/g;
             asSupport = tempElem.style.cssText.match(regex);
-            support3d = (asSupport !== null && asSupport.length === 1);
+            support3d = (asSupport !== null && asSupport.length !== 0);
 
             isTouch = "ontouchstart" in window || window.navigator.msMaxTouchPoints;
 


### PR DESCRIPTION
`tempElem.style.cssText` returns `-webkit-transform: translate3d(0px, 0px, 0px); transform: translate3d(0px, 0px, 0px);`. In such cases `asSupport` is an array consisting of more than 1 element `["translate3d(0px, 0px, 0px)", "translate3d(0px, 0px, 0px)"]`
